### PR TITLE
Remove the NotFoundException.

### DIFF
--- a/force-app/main/default/classes/libak_ErrorResponseFactory.cls
+++ b/force-app/main/default/classes/libak_ErrorResponseFactory.cls
@@ -5,7 +5,6 @@
 public class libak_ErrorResponseFactory implements libak_RestFramework.IErrorResponseFactory {
 	private Map<String, Integer> httpStatusByErrorType = new Map<String, Integer>{
 		libak_RestFramework.InvalidUriException.class.getName() => libak_RestFramework.HTTP_CODE_BAD_REQUEST,
-		libak_RestFramework.NotFoundException.class.getName() => libak_RestFramework.HTTP_CODE_NOT_FOUND,
 		libak_RestFramework.MethodNotAllowedException.class.getName() => libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED
 	};
 

--- a/force-app/main/default/classes/libak_RestFramework.cls
+++ b/force-app/main/default/classes/libak_RestFramework.cls
@@ -99,11 +99,6 @@ public class libak_RestFramework {
 	public class InvalidUriException extends Exception {}
 
 	/**
-	 * This exception is thrown when a requested resource is not found. It represents a client error (HTTP 404 Not Found).
-	 */
-	public class NotFoundException extends Exception {}
-
-	/**
 	 * This exception is thrown when an HTTP method is not allowed for a particular resource. It represents a client error (HTTP 405 Method Not Allowed).
 	 */
 	public class MethodNotAllowedException extends Exception {}

--- a/force-app/main/default/classes/tests/libak_TestErrorResponse.cls
+++ b/force-app/main/default/classes/tests/libak_TestErrorResponse.cls
@@ -5,8 +5,8 @@ public with sharing class libak_TestErrorResponse {
 	static void testErrorResponseInstance(){
 		RestContext.response = new RestResponse();
 		libak_RestFramework.IRestResponse response = new libak_ErrorResponse(
-			libak_RestFramework.HTTP_CODE_NOT_FOUND,
-			new libak_RestFramework.NotFoundException('Not found')
+			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
+			new libak_RestFramework.InvalidUriException('Bad Request')
 		);
 
 		Test.startTest();
@@ -25,9 +25,9 @@ public with sharing class libak_TestErrorResponse {
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_NOT_FOUND,
+			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
 			RestContext.response.statusCode,
-			'The status code of response should be 200'
+			'The status code of response should be ' + libak_RestFramework.HTTP_CODE_BAD_REQUEST
 		);
 		System.assertEquals(
 			Blob.valueOf(JSON.serialize(response)),


### PR DESCRIPTION
Remove the possibility of throwing a NOT FOUND error from the business logic code as it’s not really needed and slower than returning an error response