### PR TITLE
bugfix/fix the invalid uri error when slash character at the and of the request URI

### DIFF
--- a/force-app/main/default/classes/libak_RestRouter.cls
+++ b/force-app/main/default/classes/libak_RestRouter.cls
@@ -54,6 +54,6 @@ public abstract class libak_RestRouter {
 			.replaceAll('\\*', '\\.+')
 			.replaceAll('\\:(.+?)/', '\\.+/')
 			.replaceAll('\\:(.+?)$', '\\.+');
-		return Pattern.matches('(?i)' + routeTemplateRegEx, requestURI);
+		return Pattern.matches('(?i)' + routeTemplateRegEx, requestURI.replaceAll('(\\/+)$', ''));
 	}
 }

--- a/force-app/main/default/classes/tests/libak_TestRestFramework.cls
+++ b/force-app/main/default/classes/tests/libak_TestRestFramework.cls
@@ -1,12 +1,53 @@
 @IsTest
 public with sharing class libak_TestRestFramework {
 
-	public static final String URI_TEMPLATE = '/testRestFramework/:uriParam';
+	public static final String URI_TEMPLATE_WITH_PARAMS = '/testRestFramework/:uriParam';
+	public static final String URI_TEMPLATE_WITHOUT_PARAMS = '/testRestFramework';
 
 	@IsTest
 	static void testHandleRequestPositive(){
 		RestRequest request = new RestRequest();
 		request.requestURI = '/testRestFramework/param_1';
+		RestContext.request = request;
+		RestContext.response = new RestResponse();
+
+		Test.startTest();
+
+		libak_RestFramework.handleRequest(RestRouterInstance.class);
+
+		Test.stopTest();
+
+		System.assertEquals(
+			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			RestContext.response.statusCode,
+			'The status code of response should be 405'
+		);
+	}
+
+	@IsTest
+	static void testHandleRequestWithoutParamsPositive(){
+		RestRequest request = new RestRequest();
+		request.requestURI = '/testRestFramework';
+		RestContext.request = request;
+		RestContext.response = new RestResponse();
+
+		Test.startTest();
+
+		libak_RestFramework.handleRequest(RestRouterInstance.class);
+
+		Test.stopTest();
+
+		System.assertEquals(
+			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			RestContext.response.statusCode,
+			'The status code of response should be 405'
+		);
+	}
+
+	@IsTest
+	static void testHandleRequestWithoutParamsWithSlashAtTheEnd(){
+		RestRequest request = new RestRequest();
+		request.requestURI = '/testRestFramework/';
 		RestContext.request = request;
 		RestContext.response = new RestResponse();
 
@@ -56,7 +97,8 @@ public with sharing class libak_TestRestFramework {
 	private class RestRouterInstance extends libak_RestRouter {
 		override public libak_RestRouter setRoutes() {
 			this.routeToRestProcessorType = new Map<String, Type>{
-				URI_TEMPLATE => libak_RestProcessor.class
+				URI_TEMPLATE_WITH_PARAMS => libak_RestProcessor.class,
+				URI_TEMPLATE_WITHOUT_PARAMS => libak_RestProcessor.class
 			};
 			return this;
 		}


### PR DESCRIPTION
**The problem description:**
The Invalid uri issue occurs when in the Rest Router the pattern is specified like this: `/v1/customers` but in the request URI there is a slash character at the end like this `/v1/customers/`
**The solution:**
Remove unnecessary slash characters at the end from the requested URI 