### PR TITLE
bugfix/remove-status-code-from-the-error-response-json-body

### DIFF
--- a/API_Reference.md
+++ b/API_Reference.md
@@ -517,7 +517,7 @@ Constructs a new `libak_ErrorResponse` based on an exception. It sets the status
 
 #### `sendResponse()`
 
-Sends the error response with the configured status code, summary, and details. It sets the HTTP status code, response body (serialized error information in JSON format), and content type header in the RestContext's response object.
+Sends the error response with the configured summary, and details. It sets the HTTP status code, response body (serialized error information in JSON format but without statusCode property which is set only for the `RestContext.response.statusCode`), and content type header in the RestContext's response object.
 
 ---
 

--- a/force-app/main/default/classes/libak_ErrorResponse.cls
+++ b/force-app/main/default/classes/libak_ErrorResponse.cls
@@ -4,7 +4,7 @@
  */
 public class libak_ErrorResponse implements libak_IRestResponse {
 	@TestVisible
-	private Integer statusCode;
+	private transient Integer statusCode;
 	@TestVisible
 	private String summary;
 	private String details;


### PR DESCRIPTION
### Summary
This PR includes updates to the libak_ErrorResponse class and its corresponding documentation in the API_Reference.md file. The changes improve the handling of the statusCode property and clarify the behavior of the sendResponse() method.

### Impact
- Improved Response Consistency: The statusCode is now properly handled as part of the HTTP response status, rather than being included in the JSON response body.
- Enhanced Clarity: The updated documentation ensures developers understand the behavior of the sendResponse() method.
